### PR TITLE
Fix VMR error scaling and grid diagnostics

### DIFF
--- a/src/skretrieval/plotting/__init__.py
+++ b/src/skretrieval/plotting/__init__.py
@@ -1,20 +1,32 @@
 from __future__ import annotations
 
 
+def _altitude_for_state(results, state: str):
+    data = results[state]
+    for dim in data.dims:
+        if "altitude" in dim:
+            return results[dim]
+
+    msg = f"Could not determine altitude coordinate for state '{state}'"
+    raise ValueError(msg)
+
+
 def plot_state(results: dict, state: str, **kwargs):
     import matplotlib.pyplot as plt
 
     r = results["state"]
+    altitude = _altitude_for_state(r, state)
+
     plt.subplot(1, 2, 1)
-    plt.plot(r[f"{state}"], r["altitude"])
-    plt.plot(r[f"{state}_prior"], r["altitude"])
+    plt.plot(r[f"{state}"], altitude)
+    plt.plot(r[f"{state}_prior"], altitude)
     plt.legend(["Retrieved", "Prior"])
 
     plt.ylabel("Altitude [m]")
     plt.xlabel(f"{state}")
 
     plt.subplot(1, 2, 2)
-    plt.plot(r[f"{state}_averaging_kernel"], r["altitude"])
+    plt.plot(r[f"{state}_averaging_kernel"], altitude)
     plt.xlabel("Averaging Kernel")
     plt.ylabel("Altitude [m]")
 

--- a/src/skretrieval/retrieval/__init__.py
+++ b/src/skretrieval/retrieval/__init__.py
@@ -127,6 +127,10 @@ class RetrievalTarget(ABC):
     ):
         return None
 
+    @staticmethod
+    def state_vector_error_output(output_dict: dict) -> dict:
+        return output_dict
+
 
 class Minimizer(ABC):
     """

--- a/src/skretrieval/retrieval/processing.py
+++ b/src/skretrieval/retrieval/processing.py
@@ -198,6 +198,7 @@ class Retrieval:
         min_val=0,
         max_val=1,
     ):
+        alt_grid = np.asarray(alt_grid, dtype=float)
         const = sk2.climatology.mipas.constituent(species_name, optical)
 
         altitudes_m = const._constituent.altitudes_m
@@ -230,8 +231,10 @@ class Retrieval:
     def _default_state_absorber(
         processor: Retrieval, name: str, native_alt_grid: np.array, cfg: dict
     ):
+        retrieval_alt_grid = cfg.get("altitude_grid", native_alt_grid)
+
         const = processor._const_from_mipas(
-            native_alt_grid,
+            retrieval_alt_grid,
             name,
             processor._optical_property(name),
             tikh=cfg["tikh_factor"],

--- a/src/skretrieval/retrieval/rodgers.py
+++ b/src/skretrieval/retrieval/rodgers.py
@@ -190,7 +190,10 @@ class Rodgers(Minimizer):
         y_meas_dict, y_meas, Sy, inv_Sy, good_meas = self._measurement_parameters(
             retrieval_target, measurement_l1
         )
+        Sy_target = Sy
+        inv_Sy_target = inv_Sy
         x_a, inv_Sa, initial_guess = self._apriori_parameters(retrieval_target)
+        inv_Sa_target = inv_Sa
 
         xs = []
         xs.append(initial_guess)
@@ -222,9 +225,9 @@ class Rodgers(Minimizer):
 
             y_ret_dict = retrieval_target.measurement_vector(forward_l1)
 
-            K = y_ret_dict["jacobian"]
+            K_target = y_ret_dict["jacobian"][good_meas, :]
 
-            K = y_scaler_inv @ K[good_meas, :] @ x_scaler
+            K = y_scaler_inv @ K_target @ x_scaler
             y_ret = y_scaler_inv @ y_ret_dict["y"][good_meas]
 
             ys.append(y_ret_dict["y"])
@@ -399,6 +402,7 @@ class Rodgers(Minimizer):
                     x_a, inv_Sa, initial_guess = self._apriori_parameters(
                         retrieval_target
                     )
+                    inv_Sa_target = inv_Sa
 
                     if self._apply_cholesky_scaling:
                         x_scaler_inv = sparse.diags(np.sqrt(inv_Sa.diagonal()))
@@ -418,6 +422,8 @@ class Rodgers(Minimizer):
                         inv_Sy,
                         good_meas,
                     ) = self._measurement_parameters(retrieval_target, measurement_l1)
+                    Sy_target = Sy
+                    inv_Sy_target = inv_Sy
                     if self._apply_cholesky_scaling:
                         y_scaler = sparse.diags(1 / np.sqrt(inv_Sy.diagonal()))
                         y_scaler_inv = sparse.diags(np.sqrt(inv_Sy.diagonal()))
@@ -429,7 +435,10 @@ class Rodgers(Minimizer):
                     inv_Sy = y_scaler @ inv_Sy @ y_scaler
 
         if self._max_iter > 0:
-            output_dict.update(estimate_error(K, Sy, inv_Sy, inv_Sa, A_without_lm))
+            output_dict.update(
+                estimate_error(K_target, Sy_target, inv_Sy_target, inv_Sa_target)
+            )
+            output_dict = retrieval_target.state_vector_error_output(output_dict)
 
         output_dict["xs"] = xs
         output_dict["ys"] = ys

--- a/src/skretrieval/retrieval/scipy.py
+++ b/src/skretrieval/retrieval/scipy.py
@@ -237,7 +237,7 @@ class SciPyMinimizer(Minimizer):
 
         results.update(estimate_error(K, Sy, inv_Sy, inv_Sa))
 
-        return results
+        return retrieval_target.state_vector_error_output(results)
 
 
 class SciPyMinimizerGrad(Minimizer):

--- a/src/skretrieval/retrieval/statevector/altitude.py
+++ b/src/skretrieval/retrieval/statevector/altitude.py
@@ -106,7 +106,9 @@ class AltitudeNativeStateVector(StateVector):
         -------
         xr.Dataset
         """
-        result = super().describe(rodgers_output)
+        result = super().describe(
+            rodgers_output, model_altitude_grid=self._altitude_grid
+        )
 
         result.coords["altitude"] = self._altitude_grid
 

--- a/src/skretrieval/retrieval/statevector/constituent.py
+++ b/src/skretrieval/retrieval/statevector/constituent.py
@@ -14,6 +14,29 @@ def _as_scalar(value) -> float:
     return float(np.asarray(value).reshape(-1)[0])
 
 
+def _altitude_grids_match(altitude_grid: np.ndarray, model_altitude_grid) -> bool:
+    if model_altitude_grid is None:
+        return False
+
+    model_altitude_grid = np.asarray(model_altitude_grid)
+    return altitude_grid.shape == model_altitude_grid.shape and np.allclose(
+        altitude_grid, model_altitude_grid
+    )
+
+
+def _physical_1sigma(
+    covariance: np.ndarray,
+    state_slice: slice,
+    scale_factor: float,
+    property_values,
+    log_space: bool,
+) -> np.ndarray:
+    sigma = np.sqrt(np.diag(covariance)[state_slice])
+    if log_space:
+        return sigma * np.asarray(property_values)
+    return sigma / scale_factor
+
+
 class StateVectorElementConstituent(
     StateVectorElement, sk2.constituent.base.Constituent
 ):
@@ -216,8 +239,52 @@ class StateVectorElementConstituent(
             else:
                 setattr(self._constituent, key, getattr(self._constituent, key) * value)
 
+    def _constituent_altitude_grid(self, property_length: int) -> np.ndarray | None:
+        for attr_name in ("altitudes_m", "_altitudes_m", "_altitude_grid_m"):
+            if hasattr(self._constituent, attr_name):
+                altitude_grid = np.asarray(getattr(self._constituent, attr_name))
+                if altitude_grid.shape == (property_length,):
+                    return altitude_grid
+
+        nested_constituent = getattr(self._constituent, "_constituent", None)
+        if nested_constituent is not None and hasattr(
+            nested_constituent, "altitudes_m"
+        ):
+            altitude_grid = np.asarray(nested_constituent.altitudes_m)
+            if altitude_grid.shape == (property_length,):
+                return altitude_grid
+
+        return None
+
+    def _profile_dims_and_coords(
+        self, property_length: int, model_altitude_grid
+    ) -> tuple[str, str, dict[str, np.ndarray]]:
+        altitude_grid = self._constituent_altitude_grid(property_length)
+
+        if altitude_grid is None and model_altitude_grid is not None:
+            model_altitude_grid = np.asarray(model_altitude_grid)
+            if model_altitude_grid.shape == (property_length,):
+                altitude_grid = model_altitude_grid
+
+        if altitude_grid is None or _altitude_grids_match(
+            altitude_grid, model_altitude_grid
+        ):
+            altitude_dim = "altitude"
+            altitude_dim_2 = "altitude_2"
+        else:
+            altitude_dim = f"{self._constituent_name}_altitude"
+            altitude_dim_2 = f"{altitude_dim}_2"
+
+        coords = {}
+        if altitude_grid is not None:
+            coords[altitude_dim] = altitude_grid
+            coords[altitude_dim_2] = altitude_grid
+
+        return altitude_dim, altitude_dim_2, coords
+
     def describe(self, **kwargs) -> xr.Dataset | None:
         ds = xr.Dataset()
+        model_altitude_grid = kwargs.get("model_altitude_grid")
 
         if (
             type(self._constituent)
@@ -231,7 +298,13 @@ class StateVectorElementConstituent(
                 coords={self._constituent._interp_var: self._constituent._x},
             )
             ds[self._constituent_name + "_1sigma_error"] = xr.DataArray(
-                np.sqrt(np.diag(kwargs["covariance"])),
+                _physical_1sigma(
+                    kwargs["covariance"],
+                    slice(None),
+                    self._scale_factor,
+                    albedo,
+                    self._log_space,
+                ),
                 dims=[self._constituent._interp_var],
                 coords={self._constituent._interp_var: self._constituent._x},
             )
@@ -250,38 +323,30 @@ class StateVectorElementConstituent(
                 else:
                     prior_values = self._prior[property_name].state / self._scale_factor
 
-                ds[self._constituent_name + "_" + property_name + "_prior"] = (
-                    xr.DataArray(prior_values, dims=["altitude"])
-                )
                 if end - start == 1:  # scalar property
                     ds[self._constituent_name + "_" + property_name] = xr.DataArray(
                         _as_scalar(getattr(self._constituent, property_name))
                     )
 
                     ds[self._constituent_name + "_" + property_name + "_prior"] = (
-                        _as_scalar(self._prior[property_name].state)
+                        _as_scalar(prior_values)
                     )
 
                     if "covariance" in kwargs:
-                        if self._log_space:
-                            ds[
-                                self._constituent_name
-                                + "_"
-                                + property_name
-                                + "_1sigma_error"
-                            ] = _as_scalar(
-                                np.sqrt(np.diag(kwargs["covariance"])[start:end])
-                                * getattr(self._constituent, property_name)
+                        ds[
+                            self._constituent_name
+                            + "_"
+                            + property_name
+                            + "_1sigma_error"
+                        ] = _as_scalar(
+                            _physical_1sigma(
+                                kwargs["covariance"],
+                                slice(start, end),
+                                self._scale_factor,
+                                getattr(self._constituent, property_name),
+                                self._log_space,
                             )
-                        else:
-                            ds[
-                                self._constituent_name
-                                + "_"
-                                + property_name
-                                + "_1sigma_error"
-                            ] = _as_scalar(
-                                np.sqrt(np.diag(kwargs["covariance"])[start:end])
-                            )
+                        )
 
                     if "averaging_kernel" in kwargs:
                         ds[
@@ -291,38 +356,54 @@ class StateVectorElementConstituent(
                             + "_averaging_kernel"
                         ] = _as_scalar(kwargs["averaging_kernel"][start:end, start:end])
                 else:
+                    altitude_dim, altitude_dim_2, coords = (
+                        self._profile_dims_and_coords(end - start, model_altitude_grid)
+                    )
+                    profile_coords = (
+                        {altitude_dim: coords[altitude_dim]}
+                        if altitude_dim in coords
+                        else None
+                    )
+                    ak_coords = (
+                        {
+                            altitude_dim: coords[altitude_dim],
+                            altitude_dim_2: coords[altitude_dim_2],
+                        }
+                        if altitude_dim in coords and altitude_dim_2 in coords
+                        else None
+                    )
+
                     ds[self._constituent_name + "_" + property_name] = xr.DataArray(
-                        getattr(self._constituent, property_name), dims=["altitude"]
+                        getattr(self._constituent, property_name),
+                        dims=[altitude_dim],
+                        coords=profile_coords,
                     )
 
                     ds[self._constituent_name + "_" + property_name + "_prior"] = (
                         xr.DataArray(
-                            self._prior[property_name].state, dims=["altitude"]
+                            prior_values,
+                            dims=[altitude_dim],
+                            coords=profile_coords,
                         )
                     )
 
                     if "covariance" in kwargs:
-                        if self._log_space:
-                            ds[
-                                self._constituent_name
-                                + "_"
-                                + property_name
-                                + "_1sigma_error"
-                            ] = xr.DataArray(
-                                np.sqrt(np.diag(kwargs["covariance"])[start:end])
-                                * getattr(self._constituent, property_name),
-                                dims=["altitude"],
-                            )
-                        else:
-                            ds[
-                                self._constituent_name
-                                + "_"
-                                + property_name
-                                + "_1sigma_error"
-                            ] = xr.DataArray(
-                                np.sqrt(np.diag(kwargs["covariance"])[start:end]),
-                                dims=["altitude"],
-                            )
+                        ds[
+                            self._constituent_name
+                            + "_"
+                            + property_name
+                            + "_1sigma_error"
+                        ] = xr.DataArray(
+                            _physical_1sigma(
+                                kwargs["covariance"],
+                                slice(start, end),
+                                self._scale_factor,
+                                getattr(self._constituent, property_name),
+                                self._log_space,
+                            ),
+                            dims=[altitude_dim],
+                            coords=profile_coords,
+                        )
 
                     if "averaging_kernel" in kwargs:
                         ds[
@@ -332,7 +413,8 @@ class StateVectorElementConstituent(
                             + "_averaging_kernel"
                         ] = xr.DataArray(
                             kwargs["averaging_kernel"][start:end, start:end],
-                            dims=["altitude", "altitude_2"],
+                            dims=[altitude_dim, altitude_dim_2],
+                            coords=ak_coords,
                         )
 
                 start = end

--- a/src/skretrieval/retrieval/target/__init__.py
+++ b/src/skretrieval/retrieval/target/__init__.py
@@ -99,13 +99,18 @@ class LogisticBoundingMixin:
         """
         if not self._rescale_state_elements:
             return K
+        return K @ np.diag(self._bounded_state_derivative_by_internal())
+
+    def _bounded_state_derivative_by_internal(self) -> np.ndarray:
+        if not self._rescale_state_elements:
+            return np.ones_like(self.state_vector())
+
         x = self._map_internal_to_bounded(self.state_vector())
         lb = self.lower_bound()
         ub = self.upper_bound()
         mapping = np.zeros_like(x)
 
         no_map = (lb == -np.inf) & (ub == np.inf)
-
         both_bounds = (lb != -np.inf) & (ub != np.inf)
 
         mapping[no_map] = 1
@@ -115,7 +120,7 @@ class LogisticBoundingMixin:
             / (ub[both_bounds] - lb[both_bounds])
         )
 
-        return K @ np.diag(mapping)
+        return mapping
 
     def _map_inv_Sa_by_dinternal(self, x: np.array, inv_Sa: np.ndarray) -> np.ndarray:
         """
@@ -361,6 +366,30 @@ class GenericTarget(RetrievalTarget, LogisticBoundingMixin):
         return self._map_inv_Sa_by_dinternal(
             self.state_vector(), block_diag(*inv_covar)
         )
+
+    def state_vector_error_output(self, output_dict: dict) -> dict:
+        if not self._rescale_state_elements:
+            return output_dict
+
+        mapping = self._bounded_state_derivative_by_internal()
+        transform = np.diag(mapping)
+        inv_transform = np.diag(1 / mapping)
+
+        result = output_dict.copy()
+
+        for key in ("error_covariance_from_noise", "solution_covariance"):
+            if key in result:
+                result[key] = transform @ result[key] @ transform
+
+        if "gain_matrix" in result:
+            result["gain_matrix"] = transform @ result["gain_matrix"]
+
+        if "averaging_kernel" in result:
+            result["averaging_kernel"] = (
+                transform @ result["averaging_kernel"] @ inv_transform
+            )
+
+        return result
 
     def update_state_slices(self):
         # Construct slices that map the full state vector to each individual state vector element

--- a/tests/retrieval/statevector/test_statevector_constituent.py
+++ b/tests/retrieval/statevector/test_statevector_constituent.py
@@ -4,6 +4,8 @@ import numpy as np
 import sasktran2 as sk2
 
 from skretrieval.retrieval.prior import ManualPrior
+from skretrieval.retrieval.processing import Retrieval
+from skretrieval.retrieval.statevector.altitude import AltitudeNativeStateVector
 from skretrieval.retrieval.statevector.constituent import StateVectorElementConstituent
 
 
@@ -46,3 +48,101 @@ def test_statevector_constituent_describe_scalar_array():
     assert result["scalar_scalar_property_prior"].item() == 1.0
     assert result["scalar_scalar_property_1sigma_error"].item() == 0.5
     assert result["scalar_scalar_property_averaging_kernel"].item() == 0.8
+
+
+def test_statevector_constituent_describe_scales_linear_profile_error():
+    class ProfileConstituent:
+        altitudes_m = np.array([0.0, 1000.0, 2000.0])
+        vmr = np.array([1.0e-6, 2.0e-6, 3.0e-6])
+
+    scale_factor = 1000.0
+    sv = StateVectorElementConstituent(
+        ProfileConstituent(),
+        "o3",
+        ["vmr"],
+        prior={
+            "vmr": ManualPrior(
+                np.array([1.0e-3, 2.0e-3, 3.0e-3]),
+                np.eye(3),
+            )
+        },
+        scale_factor=scale_factor,
+    )
+
+    result = sv.describe(
+        covariance=np.diag([1.0, 4.0, 9.0]),
+        averaging_kernel=np.eye(3),
+    )
+
+    np.testing.assert_allclose(
+        result["o3_vmr_1sigma_error"],
+        np.array([1.0, 2.0, 3.0]) / scale_factor,
+    )
+
+
+def _absorber_config(**kwargs):
+    cfg = {
+        "prior_influence": 5e0,
+        "tikh_factor": 1e-2,
+        "log_space": False,
+        "min_value": 0,
+        "max_value": 1,
+    }
+    cfg.update(kwargs)
+    return cfg
+
+
+def _rodgers_output(num_state: int):
+    return {
+        "error_covariance_from_noise": np.eye(num_state) * 0.25,
+        "averaging_kernel": np.eye(num_state),
+    }
+
+
+def test_default_absorber_can_use_separate_retrieval_altitude_grid():
+    model_grid = np.arange(0, 70001, 5000.0)
+    retrieval_grid = np.arange(0, 70001, 10000.0)
+    processor = Retrieval.__new__(Retrieval)
+
+    absorber = Retrieval._default_state_absorber(
+        processor,
+        "o3",
+        model_grid,
+        _absorber_config(altitude_grid=retrieval_grid),
+    )
+    state_vector = AltitudeNativeStateVector(model_grid, o3=absorber)
+    result = state_vector.describe(_rodgers_output(len(absorber.state())))
+
+    assert absorber.state().shape == retrieval_grid.shape
+    assert result["o3_vmr"].dims == ("o3_altitude",)
+    assert result["o3_vmr_prior"].dims == ("o3_altitude",)
+    assert result["o3_vmr_1sigma_error"].dims == ("o3_altitude",)
+    assert result["o3_vmr_averaging_kernel"].dims == (
+        "o3_altitude",
+        "o3_altitude_2",
+    )
+    np.testing.assert_allclose(result["o3_altitude"], retrieval_grid)
+    np.testing.assert_allclose(result["o3_altitude_2"], retrieval_grid)
+    np.testing.assert_allclose(result["altitude"], model_grid)
+
+
+def test_default_absorber_keeps_legacy_altitude_dim_on_model_grid():
+    model_grid = np.arange(0, 70001, 5000.0)
+    processor = Retrieval.__new__(Retrieval)
+
+    absorber = Retrieval._default_state_absorber(
+        processor,
+        "o3",
+        model_grid,
+        _absorber_config(),
+    )
+    state_vector = AltitudeNativeStateVector(model_grid, o3=absorber)
+    result = state_vector.describe(_rodgers_output(len(absorber.state())))
+
+    assert absorber.state().shape == model_grid.shape
+    assert result["o3_vmr"].dims == ("altitude",)
+    assert result["o3_vmr_prior"].dims == ("altitude",)
+    assert result["o3_vmr_1sigma_error"].dims == ("altitude",)
+    assert result["o3_vmr_averaging_kernel"].dims == ("altitude", "altitude_2")
+    assert "o3_altitude" not in result.dims
+    np.testing.assert_allclose(result["altitude"], model_grid)

--- a/tests/retrieval/test_error_estimates.py
+++ b/tests/retrieval/test_error_estimates.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import numpy as np
+
+from skretrieval.retrieval import ForwardModel, RetrievalTarget
+from skretrieval.retrieval.rodgers import Rodgers
+from skretrieval.retrieval.statevector import StateVector, StateVectorElement
+from skretrieval.retrieval.target.mvtarget import MeasVecTarget
+
+
+class LinearForwardModel(ForwardModel):
+    def calculate_radiance(self):
+        return "model"
+
+
+class LinearTarget(RetrievalTarget):
+    def __init__(self):
+        self._x = np.array([0.1, -0.2])
+        self._xa = np.array([0.0, 0.0])
+        self._inv_sa = np.diag([0.5, 2.0])
+        self._y_error = np.array([0.25, 4.0, 9.0])
+        self._k = np.array(
+            [
+                [1.0, 0.2],
+                [0.3, 2.0],
+                [1.5, -0.5],
+            ]
+        )
+        self._y_meas = np.array([1.0, -0.5, 0.25])
+
+    def state_vector(self):
+        return self._x
+
+    def measurement_vector(self, l1_data):
+        y = self._y_meas if l1_data == "measurement" else self._k @ self._x
+        return {"y": y, "jacobian": self._k, "y_error": self._y_error}
+
+    def update_state(self, x: np.ndarray):
+        self._x = x
+
+    def apriori_state(self) -> np.ndarray:
+        return self._xa
+
+    def inverse_apriori_covariance(self):
+        return self._inv_sa
+
+
+class BoundedElement(StateVectorElement):
+    def __init__(self):
+        super().__init__()
+        self._state = np.array([0.2, 1.4])
+
+    def state(self) -> np.ndarray:
+        return self._state
+
+    def lower_bound(self) -> np.ndarray:
+        return np.array([0.0, 0.0])
+
+    def upper_bound(self) -> np.ndarray:
+        return np.array([1.0, 2.0])
+
+    def name(self) -> str:
+        return "bounded"
+
+    def propagate_wf(self, radiance):
+        return radiance
+
+    def update_state(self, x: np.ndarray):
+        self._state = x
+
+
+def test_rodgers_error_estimates_are_independent_of_cholesky_scaling():
+    unscaled = Rodgers(
+        max_iter=1,
+        lm_damping=0,
+        iterative_update_lm=False,
+        apply_cholesky_scaling=False,
+    ).retrieve("measurement", LinearForwardModel(), LinearTarget())
+
+    scaled = Rodgers(
+        max_iter=1,
+        lm_damping=0,
+        iterative_update_lm=False,
+        apply_cholesky_scaling=True,
+    ).retrieve("measurement", LinearForwardModel(), LinearTarget())
+
+    for key in (
+        "error_covariance_from_noise",
+        "solution_covariance",
+        "averaging_kernel",
+    ):
+        np.testing.assert_allclose(scaled[key], unscaled[key])
+
+
+def test_bounded_target_error_output_maps_to_state_vector_coordinates():
+    target = MeasVecTarget(
+        StateVector([BoundedElement()]),
+        measurement_vectors={},
+        context={},
+        rescale_state_space=True,
+    )
+    averaging_kernel = np.array([[1.0, 2.0], [3.0, 4.0]])
+    gain_matrix = np.ones((2, 3))
+    output = {
+        "error_covariance_from_noise": np.eye(2),
+        "solution_covariance": np.eye(2) * 2,
+        "averaging_kernel": averaging_kernel,
+        "gain_matrix": gain_matrix,
+    }
+
+    result = target.state_vector_error_output(output)
+
+    mapping = np.array([0.2 * 0.8, 1.4 * 0.6 / 2])
+    transform = np.diag(mapping)
+    inv_transform = np.diag(1 / mapping)
+
+    np.testing.assert_allclose(
+        result["error_covariance_from_noise"], transform @ transform
+    )
+    np.testing.assert_allclose(
+        result["solution_covariance"],
+        transform @ output["solution_covariance"] @ transform,
+    )
+    np.testing.assert_allclose(result["gain_matrix"], transform @ gain_matrix)
+    np.testing.assert_allclose(
+        result["averaging_kernel"], transform @ averaging_kernel @ inv_transform
+    )

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from skretrieval.plotting import plot_state
+
+
+def test_plot_state_uses_state_specific_altitude_coordinate():
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg", force=True)
+    import matplotlib.pyplot as plt
+
+    retrieval_grid = np.array([0.0, 10000.0, 20000.0])
+    model_grid = np.array([0.0, 5000.0, 10000.0, 15000.0, 20000.0])
+    state = xr.Dataset(
+        {
+            "o3_vmr": xr.DataArray(
+                np.array([1.0, 2.0, 3.0]),
+                dims=["o3_altitude"],
+                coords={"o3_altitude": retrieval_grid},
+            ),
+            "o3_vmr_prior": xr.DataArray(
+                np.array([1.5, 2.5, 3.5]),
+                dims=["o3_altitude"],
+                coords={"o3_altitude": retrieval_grid},
+            ),
+            "o3_vmr_averaging_kernel": xr.DataArray(
+                np.eye(len(retrieval_grid)),
+                dims=["o3_altitude", "o3_altitude_2"],
+                coords={
+                    "o3_altitude": retrieval_grid,
+                    "o3_altitude_2": retrieval_grid,
+                },
+            ),
+        },
+        coords={"altitude": model_grid},
+    )
+
+    plot_state({"state": state}, "o3_vmr")
+
+    axes = plt.gcf().axes
+    np.testing.assert_allclose(axes[0].lines[0].get_ydata(), retrieval_grid)
+    np.testing.assert_allclose(axes[0].lines[1].get_ydata(), retrieval_grid)
+    np.testing.assert_allclose(axes[1].lines[0].get_ydata(), retrieval_grid)
+    plt.close("all")


### PR DESCRIPTION
## Summary

- Convert linear constituent 1-sigma errors from retrieval-state units back to physical property units, including VMR scale factors.
- Preserve separate retrieval altitude coordinates when absorber state grids differ from the model altitude grid, including plotting support.
- Report Rodgers/SciPy error diagnostics in state-vector coordinates after solver scaling or bounded-state transforms.

## Root Cause

VMR values were reported in physical units, but the linear-space covariance diagonal was still interpreted in retrieval-state units. In addition, Rodgers error diagnostics could be left in Cholesky-scaled solver coordinates, and bounded target diagnostics needed to be transformed back before state-vector reporting.

## Validation

- `pixi run pytest tests/`
- `pixi run pre-commit`

Both pass locally. Two legacy/core tests are skipped because optional `sasktran` is not installed in the Pixi environment.